### PR TITLE
FUL-24035: Handle celery worker crash

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -19,7 +19,7 @@ version_info_t = namedtuple(
 )
 
 SERIES = 'Cipater'
-VERSION = version_info_t(3, 1, 26, '', '')
+VERSION = version_info_t(3, 1, 25, '-beekeeper-1', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -19,7 +19,7 @@ version_info_t = namedtuple(
 )
 
 SERIES = 'Cipater'
-VERSION = version_info_t(3, 1, 25, '', '')
+VERSION = version_info_t(3, 1, 26, '', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -439,13 +439,16 @@ class Request(object):
                     send_failed_event = False  # already sent revoked event
 
             # (acks_late) acknowledge after result stored.
-            if self.task.acks_late and isinstance(exc, WorkerLostError):
-                #: For acks_late set to True, we changed the default behavior
-                #: to handle worker crash. Currently, we allow the message to be rejected
-                #: and requeued so it will be executed again by another worker.
-                self.reject(requeue=True)
-            elif self.task.acks_late:
-                self.acknowledge()
+            if self.task.acks_late:
+                reject_and_requeue = (isinstance(exc, WorkerLostError) and
+                                      self.delivery_info.get('redelivered', False) is False)
+                if reject_and_requeue:
+                    #: For acks_late set to True, we changed the default behavior
+                    #: to handle worker crash. Currently, we allow the message to be rejected
+                    #: and requeued so it will be executed again by another worker.
+                    self.reject(requeue=True)
+                else:
+                    self.acknowledge()
         self._log_error(exc_info, send_failed_event=send_failed_event)
 
     def _log_error(self, einfo, send_failed_event=True):

--- a/celery/worker/job.py
+++ b/celery/worker/job.py
@@ -437,8 +437,14 @@ class Request(object):
                     self._announce_revoked(
                         'terminated', True, string(exc), False)
                     send_failed_event = False  # already sent revoked event
+
             # (acks_late) acknowledge after result stored.
-            if self.task.acks_late:
+            if self.task.acks_late and isinstance(exc, WorkerLostError):
+                #: For acks_late set to True, we changed the default behavior
+                #: to handle worker crash. Currently, we allow the message to be rejected
+                #: and requeued so it will be executed again by another worker.
+                self.reject(requeue=True)
+            elif self.task.acks_late:
                 self.acknowledge()
         self._log_error(exc_info, send_failed_event=send_failed_event)
 


### PR DESCRIPTION
Changed the default behaviour to handle celery worker crash. Allow the message to be rejected and requeued so it will be executed again by another worker.